### PR TITLE
Easier editing

### DIFF
--- a/src/main/java/seedu/address/logic/commands/CommandResult.java
+++ b/src/main/java/seedu/address/logic/commands/CommandResult.java
@@ -11,39 +11,15 @@ public class CommandResult {
 
     private final String feedbackToUser;
 
-    /** Help information should be shown to the user. */
-    private final boolean showHelp;
-
-    /** The application should exit. */
-    private final boolean exit;
-
     /**
      * Constructs a {@code CommandResult} with the specified fields.
      */
-    public CommandResult(String feedbackToUser, boolean showHelp, boolean exit) {
-        this.feedbackToUser = requireNonNull(feedbackToUser);
-        this.showHelp = showHelp;
-        this.exit = exit;
-    }
-
-    /**
-     * Constructs a {@code CommandResult} with the specified {@code feedbackToUser},
-     * and other fields set to their default value.
-     */
     public CommandResult(String feedbackToUser) {
-        this(feedbackToUser, false, false);
+        this.feedbackToUser = requireNonNull(feedbackToUser);
     }
 
     public String getFeedbackToUser() {
         return feedbackToUser;
-    }
-
-    public boolean isShowHelp() {
-        return showHelp;
-    }
-
-    public boolean isExit() {
-        return exit;
     }
 
     @Override
@@ -52,20 +28,17 @@ public class CommandResult {
             return true;
         }
 
-        // instanceof handles nulls
-        if (!(other instanceof CommandResult)) {
+        if (other == null || other.getClass() != this.getClass()) {
             return false;
         }
 
         CommandResult otherCommandResult = (CommandResult) other;
-        return feedbackToUser.equals(otherCommandResult.feedbackToUser)
-                && showHelp == otherCommandResult.showHelp
-                && exit == otherCommandResult.exit;
+        return feedbackToUser.equals(otherCommandResult.feedbackToUser);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(feedbackToUser, showHelp, exit);
+        return Objects.hash(feedbackToUser, this.getClass());
     }
 
 }

--- a/src/main/java/seedu/address/logic/commands/CommandResult.java
+++ b/src/main/java/seedu/address/logic/commands/CommandResult.java
@@ -25,7 +25,7 @@ public class CommandResult {
             return true;
         }
 
-        if (other == null || other.getClass() != this.getClass()) {
+        if (other == null || other.getClass() != getClass()) {
             return false;
         }
 
@@ -35,7 +35,7 @@ public class CommandResult {
 
     @Override
     public int hashCode() {
-        return Objects.hash(feedbackToUser, this.getClass());
+        return Objects.hash(feedbackToUser, getClass());
     }
 
 }

--- a/src/main/java/seedu/address/logic/commands/CommandResult.java
+++ b/src/main/java/seedu/address/logic/commands/CommandResult.java
@@ -5,15 +5,12 @@ import static java.util.Objects.requireNonNull;
 import java.util.Objects;
 
 /**
- * Represents the result of a command execution.
+ * Represents the result of a command execution and the updates delegated to MainWindow.
  */
 public class CommandResult {
 
     private final String feedbackToUser;
 
-    /**
-     * Constructs a {@code CommandResult} with the specified fields.
-     */
     public CommandResult(String feedbackToUser) {
         this.feedbackToUser = requireNonNull(feedbackToUser);
     }

--- a/src/main/java/seedu/address/logic/commands/EditCommand.java
+++ b/src/main/java/seedu/address/logic/commands/EditCommand.java
@@ -94,9 +94,25 @@ public class EditCommand extends Command {
             return new CommandResult(String.format(MESSAGE_EDIT_PERSON_SUCCESS, editedPerson));
         } else {
             Person personToEdit = lastShownList.get(index.getZeroBased());
-            // todo: generate the actual command to pre-fill
-            String updatedText = String.format("%s %d %s", COMMAND_WORD, index.getOneBased(), personToEdit.getName());
-            int cursorPos = 0;
+            Name name = personToEdit.getName();
+            Phone phone = personToEdit.getPhone();
+            Email email = personToEdit.getEmail();
+            Address address = personToEdit.getAddress();
+            Set<Tag> tags = personToEdit.getTags();
+
+            final StringBuilder builder = new StringBuilder();
+            for (Tag tag : tags) {
+                builder.append(" ").append(PREFIX_TAG).append(tag.tagName);
+            }
+            String updatedText = String.format("%s %d %s%s %s%s %s%s %s%s%s",
+                    COMMAND_WORD,
+                    index.getOneBased(),
+                    PREFIX_NAME, name,
+                    PREFIX_PHONE, phone,
+                    PREFIX_EMAIL, email,
+                    PREFIX_ADDRESS, address,
+                    builder.toString());
+            int cursorPos = updatedText.length();
             return new PrefillCommandBoxCommandResult(updatedText, cursorPos);
         }
     }

--- a/src/main/java/seedu/address/logic/commands/EditCommand.java
+++ b/src/main/java/seedu/address/logic/commands/EditCommand.java
@@ -48,7 +48,6 @@ public class EditCommand extends Command {
             + PREFIX_EMAIL + "johndoe@example.com";
 
     public static final String MESSAGE_EDIT_PERSON_SUCCESS = "Edited Person: %1$s";
-    public static final String MESSAGE_NOT_EDITED = "At least one field to edit must be provided.";
     public static final String MESSAGE_DUPLICATE_PERSON = "This person already exists in the address book.";
 
     private final Index index;

--- a/src/main/java/seedu/address/logic/commands/EditCommand.java
+++ b/src/main/java/seedu/address/logic/commands/EditCommand.java
@@ -48,6 +48,7 @@ public class EditCommand extends Command {
             + PREFIX_EMAIL + "johndoe@example.com";
 
     public static final String MESSAGE_EDIT_PERSON_SUCCESS = "Edited Person: %1$s";
+    public static final String MESSAGE_EDIT_PERSON_AUTOCOMPLETE = "";
     public static final String MESSAGE_DUPLICATE_PERSON = "This person already exists in the address book.";
 
     private final Index index;
@@ -111,8 +112,7 @@ public class EditCommand extends Command {
                     PREFIX_EMAIL, email,
                     PREFIX_ADDRESS, address,
                     builder.toString());
-            int cursorPos = updatedText.length();
-            return new PrefillCommandBoxCommandResult(updatedText, cursorPos);
+            return new PrefillCommandBoxCommandResult(MESSAGE_EDIT_PERSON_AUTOCOMPLETE, updatedText);
         }
     }
 

--- a/src/main/java/seedu/address/logic/commands/ExitCommand.java
+++ b/src/main/java/seedu/address/logic/commands/ExitCommand.java
@@ -14,7 +14,7 @@ public class ExitCommand extends Command {
 
     @Override
     public CommandResult execute(Model model, CommandHistory history) {
-        return new CommandResult(MESSAGE_EXIT_ACKNOWLEDGEMENT, false, true);
+        return new ExitCommandResult(MESSAGE_EXIT_ACKNOWLEDGEMENT);
     }
 
 }

--- a/src/main/java/seedu/address/logic/commands/ExitCommandResult.java
+++ b/src/main/java/seedu/address/logic/commands/ExitCommandResult.java
@@ -1,7 +1,7 @@
 package seedu.address.logic.commands;
 
 /**
- * Represents the result of a command execution.
+ * Represents a command result that exits the application.
  */
 public class ExitCommandResult extends CommandResult {
 

--- a/src/main/java/seedu/address/logic/commands/ExitCommandResult.java
+++ b/src/main/java/seedu/address/logic/commands/ExitCommandResult.java
@@ -1,0 +1,11 @@
+package seedu.address.logic.commands;
+
+/**
+ * Represents the result of a command execution.
+ */
+public class ExitCommandResult extends CommandResult {
+
+    public ExitCommandResult(String feedbackToUser) {
+        super(feedbackToUser);
+    }
+}

--- a/src/main/java/seedu/address/logic/commands/HelpCommand.java
+++ b/src/main/java/seedu/address/logic/commands/HelpCommand.java
@@ -17,6 +17,6 @@ public class HelpCommand extends Command {
 
     @Override
     public CommandResult execute(Model model, CommandHistory history) {
-        return new CommandResult(SHOWING_HELP_MESSAGE, true, false);
+        return new HelpCommandResult(SHOWING_HELP_MESSAGE);
     }
 }

--- a/src/main/java/seedu/address/logic/commands/HelpCommandResult.java
+++ b/src/main/java/seedu/address/logic/commands/HelpCommandResult.java
@@ -1,7 +1,7 @@
 package seedu.address.logic.commands;
 
 /**
- * Represents the result of a command execution.
+ * Represents a command result that launches the help window.
  */
 public class HelpCommandResult extends CommandResult {
 

--- a/src/main/java/seedu/address/logic/commands/HelpCommandResult.java
+++ b/src/main/java/seedu/address/logic/commands/HelpCommandResult.java
@@ -1,0 +1,11 @@
+package seedu.address.logic.commands;
+
+/**
+ * Represents the result of a command execution.
+ */
+public class HelpCommandResult extends CommandResult {
+
+    public HelpCommandResult(String feedbackToUser) {
+        super(feedbackToUser);
+    }
+}

--- a/src/main/java/seedu/address/logic/commands/PrefillCommandBoxCommandResult.java
+++ b/src/main/java/seedu/address/logic/commands/PrefillCommandBoxCommandResult.java
@@ -1,0 +1,24 @@
+package seedu.address.logic.commands;
+
+/**
+ * Represents a command result that pre-fills the command box and repositions the cursor.
+ */
+public class PrefillCommandBoxCommandResult extends CommandResult {
+
+    private final String prefilledText;
+    private final int cursorPos;
+
+    public PrefillCommandBoxCommandResult(String prefilledText, int cursorPos) {
+        super("");
+        this.prefilledText = prefilledText;
+        this.cursorPos = cursorPos;
+    }
+
+    public String getPrefilledText() {
+        return prefilledText;
+    }
+
+    public int getCursorPos() {
+        return cursorPos;
+    }
+}

--- a/src/main/java/seedu/address/logic/commands/PrefillCommandBoxCommandResult.java
+++ b/src/main/java/seedu/address/logic/commands/PrefillCommandBoxCommandResult.java
@@ -8,20 +8,14 @@ import java.util.Objects;
 public class PrefillCommandBoxCommandResult extends CommandResult {
 
     private final String prefilledText;
-    private final int cursorPos;
 
-    public PrefillCommandBoxCommandResult(String prefilledText, int cursorPos) {
-        super("");
+    public PrefillCommandBoxCommandResult(String feedbackToUser, String prefilledText) {
+        super(feedbackToUser);
         this.prefilledText = prefilledText;
-        this.cursorPos = cursorPos;
     }
 
     public String getPrefilledText() {
         return prefilledText;
-    }
-
-    public int getCursorPos() {
-        return cursorPos;
     }
 
     @Override
@@ -30,12 +24,11 @@ public class PrefillCommandBoxCommandResult extends CommandResult {
             return false;
         }
         PrefillCommandBoxCommandResult otherCommandResult = (PrefillCommandBoxCommandResult) other;
-        return prefilledText.equals(otherCommandResult.prefilledText)
-                && cursorPos == otherCommandResult.cursorPos;
+        return prefilledText.equals(otherCommandResult.prefilledText);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(prefilledText, cursorPos, getClass());
+        return Objects.hash(super.hashCode(), prefilledText);
     }
 }

--- a/src/main/java/seedu/address/logic/commands/PrefillCommandBoxCommandResult.java
+++ b/src/main/java/seedu/address/logic/commands/PrefillCommandBoxCommandResult.java
@@ -1,5 +1,7 @@
 package seedu.address.logic.commands;
 
+import java.util.Objects;
+
 /**
  * Represents a command result that pre-fills the command box and repositions the cursor.
  */
@@ -20,5 +22,20 @@ public class PrefillCommandBoxCommandResult extends CommandResult {
 
     public int getCursorPos() {
         return cursorPos;
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        if (!super.equals(other)) {
+            return false;
+        }
+        PrefillCommandBoxCommandResult otherCommandResult = (PrefillCommandBoxCommandResult) other;
+        return prefilledText.equals(otherCommandResult.prefilledText)
+                && cursorPos == otherCommandResult.cursorPos;
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(prefilledText, cursorPos, getClass());
     }
 }

--- a/src/main/java/seedu/address/logic/parser/EditCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/EditCommandParser.java
@@ -59,7 +59,6 @@ public class EditCommandParser implements Parser<EditCommand> {
 
         // Abbreviated version of the command is given, expand full command in the text box
         if (!editPersonDescriptor.isAnyFieldEdited()) {
-            // throw new ParseException(EditCommand.MESSAGE_NOT_EDITED);
             return new EditCommand(index);
         }
 

--- a/src/main/java/seedu/address/logic/parser/EditCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/EditCommandParser.java
@@ -57,8 +57,10 @@ public class EditCommandParser implements Parser<EditCommand> {
         }
         parseTagsForEdit(argMultimap.getAllValues(PREFIX_TAG)).ifPresent(editPersonDescriptor::setTags);
 
+        // Abbreviated version of the command is given, expand full command in the text box
         if (!editPersonDescriptor.isAnyFieldEdited()) {
-            throw new ParseException(EditCommand.MESSAGE_NOT_EDITED);
+            // throw new ParseException(EditCommand.MESSAGE_NOT_EDITED);
+            return new EditCommand(index);
         }
 
         return new EditCommand(index, editPersonDescriptor);

--- a/src/main/java/seedu/address/ui/CommandBox.java
+++ b/src/main/java/seedu/address/ui/CommandBox.java
@@ -94,15 +94,6 @@ public class CommandBox extends UiPart<Region> {
     }
 
     /**
-     * Sets {@code CommandBox}'s text field with {@code text} and
-     * positions the caret at {@code cursorPos}.
-     */
-    private void replaceText(String text, int cursorPos) {
-        commandTextField.setText(text);
-        commandTextField.positionCaret(cursorPos);
-    }
-
-    /**
      * Handles the Enter button pressed event.
      */
     @FXML
@@ -113,8 +104,7 @@ public class CommandBox extends UiPart<Region> {
             historySnapshot.next();
             if (commandResult instanceof PrefillCommandBoxCommandResult) {
                 String prefilledText = ((PrefillCommandBoxCommandResult) commandResult).getPrefilledText();
-                int cursorPos = ((PrefillCommandBoxCommandResult) commandResult).getCursorPos();
-                replaceText(prefilledText, cursorPos);
+                replaceText(prefilledText);
             } else {
                 replaceText("");
             }

--- a/src/main/java/seedu/address/ui/CommandBox.java
+++ b/src/main/java/seedu/address/ui/CommandBox.java
@@ -8,6 +8,7 @@ import javafx.scene.control.TextField;
 import javafx.scene.input.KeyEvent;
 import javafx.scene.layout.Region;
 import seedu.address.logic.commands.CommandResult;
+import seedu.address.logic.commands.PrefillCommandBoxCommandResult;
 import seedu.address.logic.commands.exceptions.CommandException;
 import seedu.address.logic.parser.exceptions.ParseException;
 
@@ -93,15 +94,30 @@ public class CommandBox extends UiPart<Region> {
     }
 
     /**
+     * Sets {@code CommandBox}'s text field with {@code text} and
+     * positions the caret at {@code cursorPos}.
+     */
+    private void replaceText(String text, int cursorPos) {
+        commandTextField.setText(text);
+        commandTextField.positionCaret(cursorPos);
+    }
+
+    /**
      * Handles the Enter button pressed event.
      */
     @FXML
     private void handleCommandEntered() {
         try {
-            commandExecutor.execute(commandTextField.getText());
+            CommandResult commandResult = commandExecutor.execute(commandTextField.getText());
             initHistory();
             historySnapshot.next();
-            commandTextField.setText("");
+            if (commandResult instanceof PrefillCommandBoxCommandResult) {
+                String prefilledText = ((PrefillCommandBoxCommandResult) commandResult).getPrefilledText();
+                int cursorPos = ((PrefillCommandBoxCommandResult) commandResult).getCursorPos();
+                replaceText(prefilledText, cursorPos);
+            } else {
+                replaceText("");
+            }
         } catch (CommandException | ParseException e) {
             initHistory();
             setStyleToIndicateCommandFailure();

--- a/src/main/java/seedu/address/ui/MainWindow.java
+++ b/src/main/java/seedu/address/ui/MainWindow.java
@@ -16,6 +16,7 @@ import seedu.address.logic.Logic;
 import seedu.address.logic.commands.CommandResult;
 import seedu.address.logic.commands.HelpCommandResult;
 import seedu.address.logic.commands.ExitCommandResult;
+import seedu.address.logic.commands.PrefillCommandBoxCommandResult;
 import seedu.address.logic.commands.exceptions.CommandException;
 import seedu.address.logic.parser.exceptions.ParseException;
 
@@ -37,6 +38,7 @@ public class MainWindow extends UiPart<Stage> {
     private PersonListPanel personListPanel;
     private ResultDisplay resultDisplay;
     private HelpWindow helpWindow;
+    private CommandBox commandBox;
 
     @FXML
     private StackPane browserPlaceholder;
@@ -126,7 +128,7 @@ public class MainWindow extends UiPart<Stage> {
         StatusBarFooter statusBarFooter = new StatusBarFooter(logic.getAddressBookFilePath(), logic.getAddressBook());
         statusbarPlaceholder.getChildren().add(statusBarFooter.getRoot());
 
-        CommandBox commandBox = new CommandBox(this::executeCommand, logic.getHistory());
+        commandBox = new CommandBox(this::executeCommand, logic.getHistory());
         commandBoxPlaceholder.getChildren().add(commandBox.getRoot());
     }
 
@@ -187,9 +189,7 @@ public class MainWindow extends UiPart<Stage> {
 
             if (commandResult instanceof HelpCommandResult) {
                 handleHelp();
-            }
-
-            if (commandResult instanceof ExitCommandResult) {
+            } else if (commandResult instanceof ExitCommandResult) {
                 handleExit();
             }
 

--- a/src/main/java/seedu/address/ui/MainWindow.java
+++ b/src/main/java/seedu/address/ui/MainWindow.java
@@ -14,9 +14,8 @@ import seedu.address.commons.core.GuiSettings;
 import seedu.address.commons.core.LogsCenter;
 import seedu.address.logic.Logic;
 import seedu.address.logic.commands.CommandResult;
-import seedu.address.logic.commands.HelpCommandResult;
 import seedu.address.logic.commands.ExitCommandResult;
-import seedu.address.logic.commands.PrefillCommandBoxCommandResult;
+import seedu.address.logic.commands.HelpCommandResult;
 import seedu.address.logic.commands.exceptions.CommandException;
 import seedu.address.logic.parser.exceptions.ParseException;
 

--- a/src/main/java/seedu/address/ui/MainWindow.java
+++ b/src/main/java/seedu/address/ui/MainWindow.java
@@ -14,6 +14,8 @@ import seedu.address.commons.core.GuiSettings;
 import seedu.address.commons.core.LogsCenter;
 import seedu.address.logic.Logic;
 import seedu.address.logic.commands.CommandResult;
+import seedu.address.logic.commands.HelpCommandResult;
+import seedu.address.logic.commands.ExitCommandResult;
 import seedu.address.logic.commands.exceptions.CommandException;
 import seedu.address.logic.parser.exceptions.ParseException;
 
@@ -183,11 +185,11 @@ public class MainWindow extends UiPart<Stage> {
             logger.info("Result: " + commandResult.getFeedbackToUser());
             resultDisplay.setFeedbackToUser(commandResult.getFeedbackToUser());
 
-            if (commandResult.isShowHelp()) {
+            if (commandResult instanceof HelpCommandResult) {
                 handleHelp();
             }
 
-            if (commandResult.isExit()) {
+            if (commandResult instanceof ExitCommandResult) {
                 handleExit();
             }
 

--- a/src/test/java/seedu/address/logic/commands/CommandResultTest.java
+++ b/src/test/java/seedu/address/logic/commands/CommandResultTest.java
@@ -31,15 +31,12 @@ public class CommandResultTest {
         assertFalse(commandResult.equals(new ExitCommandResult("feedback")));
 
         // PrefillCommandBoxCommandResult -> returns false
-        assertFalse(commandResult.equals(new PrefillCommandBoxCommandResult("feedback", 0)));
+        assertFalse(commandResult.equals(new PrefillCommandBoxCommandResult("feedback", "a")));
 
         // PrefillCommandBoxCommandResult with different fields -> returns false
-        CommandResult PrefillCommandBoxCommandResult1 = new PrefillCommandBoxCommandResult("a", 0);
-        CommandResult PrefillCommandBoxCommandResult2 = new PrefillCommandBoxCommandResult("b", 0);
-        CommandResult PrefillCommandBoxCommandResult3 = new PrefillCommandBoxCommandResult("b", 1);
+        CommandResult PrefillCommandBoxCommandResult1 = new PrefillCommandBoxCommandResult("feedback", "a");
+        CommandResult PrefillCommandBoxCommandResult2 = new PrefillCommandBoxCommandResult("feedback", "b");
         assertFalse(PrefillCommandBoxCommandResult1.equals(PrefillCommandBoxCommandResult2));
-        assertFalse(PrefillCommandBoxCommandResult1.equals(PrefillCommandBoxCommandResult3));
-        assertFalse(PrefillCommandBoxCommandResult2.equals(PrefillCommandBoxCommandResult3));
     }
 
     @Test
@@ -59,14 +56,11 @@ public class CommandResultTest {
         assertNotEquals(commandResult.hashCode(), new ExitCommandResult("feedback").hashCode());
 
         // PrefillCommandBoxCommandResult -> returns different hashcode
-        assertNotEquals(commandResult.hashCode(), new PrefillCommandBoxCommandResult("feedback", 0).hashCode());
+        assertNotEquals(commandResult.hashCode(), new PrefillCommandBoxCommandResult("feedback", "a").hashCode());
 
         // PrefillCommandBoxCommandResult with different fields -> returns different hashcode
-        CommandResult PrefillCommandBoxCommandResult1 = new PrefillCommandBoxCommandResult("a", 0);
-        CommandResult PrefillCommandBoxCommandResult2 = new PrefillCommandBoxCommandResult("b", 0);
-        CommandResult PrefillCommandBoxCommandResult3 = new PrefillCommandBoxCommandResult("b", 1);
+        CommandResult PrefillCommandBoxCommandResult1 = new PrefillCommandBoxCommandResult("feedback", "a");
+        CommandResult PrefillCommandBoxCommandResult2 = new PrefillCommandBoxCommandResult("feedback", "b");
         assertNotEquals(PrefillCommandBoxCommandResult1.hashCode(), PrefillCommandBoxCommandResult2.hashCode());
-        assertNotEquals(PrefillCommandBoxCommandResult1.hashCode(), PrefillCommandBoxCommandResult3.hashCode());
-        assertNotEquals(PrefillCommandBoxCommandResult2.hashCode(), PrefillCommandBoxCommandResult3.hashCode());
     }
 }

--- a/src/test/java/seedu/address/logic/commands/CommandResultTest.java
+++ b/src/test/java/seedu/address/logic/commands/CommandResultTest.java
@@ -12,10 +12,6 @@ public class CommandResultTest {
     public void equals() {
         CommandResult commandResult = new CommandResult("feedback");
 
-        // same values -> returns true
-        assertTrue(commandResult.equals(new CommandResult("feedback")));
-        assertTrue(commandResult.equals(new CommandResult("feedback", false, false)));
-
         // same object -> returns true
         assertTrue(commandResult.equals(commandResult));
 
@@ -28,11 +24,11 @@ public class CommandResultTest {
         // different feedbackToUser value -> returns false
         assertFalse(commandResult.equals(new CommandResult("different")));
 
-        // different showHelp value -> returns false
-        assertFalse(commandResult.equals(new CommandResult("feedback", true, false)));
+        // HelpCommandResult -> returns false
+        assertFalse(commandResult.equals(new HelpCommandResult("feedback")));
 
-        // different exit value -> returns false
-        assertFalse(commandResult.equals(new CommandResult("feedback", false, true)));
+        // ExitCommandResult -> returns false
+        assertFalse(commandResult.equals(new ExitCommandResult("feedback")));
     }
 
     @Test
@@ -45,10 +41,10 @@ public class CommandResultTest {
         // different feedbackToUser value -> returns different hashcode
         assertNotEquals(commandResult.hashCode(), new CommandResult("different").hashCode());
 
-        // different showHelp value -> returns different hashcode
-        assertNotEquals(commandResult.hashCode(), new CommandResult("feedback", true, false).hashCode());
+        // HelpCommandResult -> returns different hashcode
+        assertNotEquals(commandResult.hashCode(), new HelpCommandResult("feedback").hashCode());
 
-        // different exit value -> returns different hashcode
-        assertNotEquals(commandResult.hashCode(), new CommandResult("feedback", false, true).hashCode());
+        // ExitCommandResult -> returns different hashcode
+        assertNotEquals(commandResult.hashCode(), new ExitCommandResult("feedback").hashCode());
     }
 }

--- a/src/test/java/seedu/address/logic/commands/CommandResultTest.java
+++ b/src/test/java/seedu/address/logic/commands/CommandResultTest.java
@@ -32,6 +32,14 @@ public class CommandResultTest {
 
         // PrefillCommandBoxCommandResult -> returns false
         assertFalse(commandResult.equals(new PrefillCommandBoxCommandResult("feedback", 0)));
+
+        // PrefillCommandBoxCommandResult with different fields -> returns false
+        CommandResult PrefillCommandBoxCommandResult1 = new PrefillCommandBoxCommandResult("a", 0);
+        CommandResult PrefillCommandBoxCommandResult2 = new PrefillCommandBoxCommandResult("b", 0);
+        CommandResult PrefillCommandBoxCommandResult3 = new PrefillCommandBoxCommandResult("b", 1);
+        assertFalse(PrefillCommandBoxCommandResult1.equals(PrefillCommandBoxCommandResult2));
+        assertFalse(PrefillCommandBoxCommandResult1.equals(PrefillCommandBoxCommandResult3));
+        assertFalse(PrefillCommandBoxCommandResult2.equals(PrefillCommandBoxCommandResult3));
     }
 
     @Test
@@ -51,6 +59,14 @@ public class CommandResultTest {
         assertNotEquals(commandResult.hashCode(), new ExitCommandResult("feedback").hashCode());
 
         // PrefillCommandBoxCommandResult -> returns different hashcode
-        assertNotEquals(commandResult.hashCode(), new PrefillCommandBoxCommandResult("feedback",0).hashCode());
+        assertNotEquals(commandResult.hashCode(), new PrefillCommandBoxCommandResult("feedback", 0).hashCode());
+
+        // PrefillCommandBoxCommandResult with different fields -> returns different hashcode
+        CommandResult PrefillCommandBoxCommandResult1 = new PrefillCommandBoxCommandResult("a", 0);
+        CommandResult PrefillCommandBoxCommandResult2 = new PrefillCommandBoxCommandResult("b", 0);
+        CommandResult PrefillCommandBoxCommandResult3 = new PrefillCommandBoxCommandResult("b", 1);
+        assertNotEquals(PrefillCommandBoxCommandResult1.hashCode(), PrefillCommandBoxCommandResult2.hashCode());
+        assertNotEquals(PrefillCommandBoxCommandResult1.hashCode(), PrefillCommandBoxCommandResult3.hashCode());
+        assertNotEquals(PrefillCommandBoxCommandResult2.hashCode(), PrefillCommandBoxCommandResult3.hashCode());
     }
 }

--- a/src/test/java/seedu/address/logic/commands/CommandResultTest.java
+++ b/src/test/java/seedu/address/logic/commands/CommandResultTest.java
@@ -29,6 +29,9 @@ public class CommandResultTest {
 
         // ExitCommandResult -> returns false
         assertFalse(commandResult.equals(new ExitCommandResult("feedback")));
+
+        // PrefillCommandBoxCommandResult -> returns false
+        assertFalse(commandResult.equals(new PrefillCommandBoxCommandResult("feedback", 0)));
     }
 
     @Test
@@ -46,5 +49,8 @@ public class CommandResultTest {
 
         // ExitCommandResult -> returns different hashcode
         assertNotEquals(commandResult.hashCode(), new ExitCommandResult("feedback").hashCode());
+
+        // PrefillCommandBoxCommandResult -> returns different hashcode
+        assertNotEquals(commandResult.hashCode(), new PrefillCommandBoxCommandResult("feedback",0).hashCode());
     }
 }

--- a/src/test/java/seedu/address/logic/commands/EditCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/EditCommandTest.java
@@ -11,6 +11,11 @@ import static seedu.address.logic.commands.CommandTestUtil.VALID_TAG_HUSBAND;
 import static seedu.address.logic.commands.CommandTestUtil.assertCommandFailure;
 import static seedu.address.logic.commands.CommandTestUtil.assertCommandSuccess;
 import static seedu.address.logic.commands.CommandTestUtil.showPersonAtIndex;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_ADDRESS;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_EMAIL;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_NAME;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_PHONE;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_TAG;
 import static seedu.address.testutil.TypicalIndexes.INDEX_FIRST_PERSON;
 import static seedu.address.testutil.TypicalIndexes.INDEX_SECOND_PERSON;
 import static seedu.address.testutil.TypicalPersons.getTypicalAddressBook;
@@ -26,6 +31,7 @@ import seedu.address.model.Model;
 import seedu.address.model.ModelManager;
 import seedu.address.model.UserPrefs;
 import seedu.address.model.person.Person;
+import seedu.address.model.tag.Tag;
 import seedu.address.testutil.EditPersonDescriptorBuilder;
 import seedu.address.testutil.PersonBuilder;
 
@@ -76,15 +82,24 @@ public class EditCommandTest {
 
     @Test
     public void execute_noFieldSpecifiedUnfilteredList_success() {
-        EditCommand editCommand = new EditCommand(INDEX_FIRST_PERSON, new EditPersonDescriptor());
-        Person editedPerson = model.getFilteredPersonList().get(INDEX_FIRST_PERSON.getZeroBased());
+        EditCommand editCommand = new EditCommand(INDEX_FIRST_PERSON);
+        Person firstPerson = model.getFilteredPersonList().get(0);
+        final StringBuilder builder = new StringBuilder();
+        for (Tag tag : firstPerson.getTags()) {
+            builder.append(" ").append(PREFIX_TAG).append(tag.tagName);
+        }
+        String prefilledText = String.format("%s %d %s%s %s%s %s%s %s%s%s",
+                EditCommand.COMMAND_WORD,
+                1,
+                PREFIX_NAME, firstPerson.getName(),
+                PREFIX_PHONE, firstPerson.getPhone(),
+                PREFIX_EMAIL, firstPerson.getEmail(),
+                PREFIX_ADDRESS, firstPerson.getAddress(),
+                builder.toString());
+        CommandResult expectedResult = new PrefillCommandBoxCommandResult(EditCommand.MESSAGE_EDIT_PERSON_AUTOCOMPLETE,
+                prefilledText);
 
-        String expectedMessage = String.format(EditCommand.MESSAGE_EDIT_PERSON_SUCCESS, editedPerson);
-
-        Model expectedModel = new ModelManager(new AddressBook(model.getAddressBook()), new UserPrefs());
-        expectedModel.commitAddressBook();
-
-        assertCommandSuccess(editCommand, model, commandHistory, expectedMessage, expectedModel);
+        assertCommandSuccess(editCommand, model, commandHistory, expectedResult, model);
     }
 
     @Test

--- a/src/test/java/seedu/address/logic/commands/ExitCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/ExitCommandTest.java
@@ -16,7 +16,7 @@ public class ExitCommandTest {
 
     @Test
     public void execute_exit_success() {
-        CommandResult expectedCommandResult = new CommandResult(MESSAGE_EXIT_ACKNOWLEDGEMENT, false, true);
+        CommandResult expectedCommandResult = new ExitCommandResult(MESSAGE_EXIT_ACKNOWLEDGEMENT);
         assertCommandSuccess(new ExitCommand(), model, commandHistory, expectedCommandResult, expectedModel);
     }
 }

--- a/src/test/java/seedu/address/logic/commands/HelpCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/HelpCommandTest.java
@@ -16,7 +16,7 @@ public class HelpCommandTest {
 
     @Test
     public void execute_help_success() {
-        CommandResult expectedCommandResult = new CommandResult(SHOWING_HELP_MESSAGE, true, false);
+        CommandResult expectedCommandResult = new HelpCommandResult(SHOWING_HELP_MESSAGE);
         assertCommandSuccess(new HelpCommand(), model, commandHistory, expectedCommandResult, expectedModel);
     }
 }

--- a/src/test/java/seedu/address/logic/parser/EditCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/EditCommandParserTest.java
@@ -57,9 +57,6 @@ public class EditCommandParserTest {
         // no index specified
         assertParseFailure(parser, VALID_NAME_AMY, MESSAGE_INVALID_FORMAT);
 
-        // no field specified
-        assertParseFailure(parser, "1", EditCommand.MESSAGE_NOT_EDITED);
-
         // no index and no field specified
         assertParseFailure(parser, "", MESSAGE_INVALID_FORMAT);
     }

--- a/src/test/java/seedu/address/logic/parser/EditCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/EditCommandParserTest.java
@@ -129,6 +129,16 @@ public class EditCommandParserTest {
     }
 
     @Test
+    public void parse_noFieldsSpecified_success() {
+        Index targetIndex = INDEX_FIRST_PERSON;
+        String userInput = Integer.toString(targetIndex.getOneBased());
+
+        EditCommand expectedCommand = new EditCommand(targetIndex);
+
+        assertParseSuccess(parser, userInput, expectedCommand);
+    }
+
+    @Test
     public void parse_oneFieldSpecified_success() {
         // name
         Index targetIndex = INDEX_THIRD_PERSON;

--- a/src/test/java/systemtests/EditCommandSystemTest.java
+++ b/src/test/java/systemtests/EditCommandSystemTest.java
@@ -158,6 +158,7 @@ public class EditCommandSystemTest extends AddressBookSystemTest {
         assertCommandFailure(EditCommand.COMMAND_WORD + NAME_DESC_BOB,
                 String.format(Messages.MESSAGE_INVALID_COMMAND_FORMAT, EditCommand.MESSAGE_USAGE));
 
+        // todo: update this test
         /* Case: missing all fields -> rejected */
         assertCommandFailure(EditCommand.COMMAND_WORD + " " + INDEX_FIRST_PERSON.getOneBased(),
                 EditCommand.MESSAGE_NOT_EDITED);

--- a/src/test/java/systemtests/EditCommandSystemTest.java
+++ b/src/test/java/systemtests/EditCommandSystemTest.java
@@ -158,11 +158,6 @@ public class EditCommandSystemTest extends AddressBookSystemTest {
         assertCommandFailure(EditCommand.COMMAND_WORD + NAME_DESC_BOB,
                 String.format(Messages.MESSAGE_INVALID_COMMAND_FORMAT, EditCommand.MESSAGE_USAGE));
 
-        // todo: update this test
-        /* Case: missing all fields -> rejected */
-        assertCommandFailure(EditCommand.COMMAND_WORD + " " + INDEX_FIRST_PERSON.getOneBased(),
-                EditCommand.MESSAGE_NOT_EDITED);
-
         /* Case: invalid name -> rejected */
         assertCommandFailure(EditCommand.COMMAND_WORD + " " + INDEX_FIRST_PERSON.getOneBased() + INVALID_NAME_DESC,
                 Name.MESSAGE_CONSTRAINTS);


### PR DESCRIPTION
Previously, `edit [index]` was considered a wrong command. This PR introduces a useful way to respond to such commands, by pre-filling the command box with an edit command along with all the parameters of the person at `index`.

For example, `edit 1` becomes `edit 1 n/John Doe p/98765432 e/johnd@example.com a/John street, block 123, #01-01`.

This makes it easy for users to make minor corrections and also relieves them of the burden of having to recall which prefixes to use.